### PR TITLE
add integration_tests directory, not yet working

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,37 @@ functions.
 
 ----
 
+### Testing
+
+To run the integration tests, do the following:
+1. Git clone this repository
+1. Add the following profile to your list of dbt profiles (run `dbt debug` to locate
+   your local profiles):
+   ```nofmt
+   integration_tests:
+     outputs:
+       dev:
+         type: materialize
+         threads: 1
+         host: localhost
+         port: 6875
+         user: user
+         password: password
+         dbname: materialize
+         schema: public
+     target: dev
+   ```
+1. In your terminal, navigate to the `integration_tests/dbt_utils` subdirectory:
+    ```nofmt
+   cd integration_tests/dbt_utils
+   ```
+1. Run the tests:
+    ```nofmt
+   make test-materialize
+   ```
+
+----
+
 ### Contributing
 
 We welcome contributions to this repo! To contribute a new feature or a fix,

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,4 +1,4 @@
-name: 'materialize_utils'
+name: 'materialize_dbt_utils'
 version: '0.1.0'
 config-version: 2
 

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -1,0 +1,5 @@
+
+target/
+dbt_modules/
+logs/
+env/

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,0 +1,3 @@
+name: 'materialize_dbt_utils_integration_tests'
+version: '0.1.0'
+config-version: 2

--- a/integration_tests/dbt_utils/Makefile
+++ b/integration_tests/dbt_utils/Makefile
@@ -1,0 +1,6 @@
+
+test-materialize:
+	dbt deps
+	dbt seed
+	dbt run
+	dbt test

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -1,0 +1,22 @@
+
+name: 'materialize_dbt_utils_dbt_utils_integration_tests'
+version: '1.0'
+config-version: 2
+
+profile: 'integration_tests'
+
+source-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+data-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_modules"
+
+vars:
+  dbt_utils_dispatch_list:
+    - materialize_dbt_utils
+    - dbt_utils_integration_tests

--- a/integration_tests/dbt_utils/packages.yml
+++ b/integration_tests/dbt_utils/packages.yml
@@ -1,0 +1,5 @@
+
+packages:
+  - local: ../../
+  - local: ../../dbt-utils
+  - local: ../../dbt-utils/integration_tests

--- a/macros/dbt_utils/datediff.sql
+++ b/macros/dbt_utils/datediff.sql
@@ -1,0 +1,5 @@
+{% macro materialize__datediff(first_date, second_date, datepart) %}
+
+  {{ return(dbt_utils.postgres__datediff(first_date, second_date, datepart)) }}
+
+{% endmacro %}


### PR DESCRIPTION
Trying to run `make test-materialize` from `integration_tests/dbt_utils` fails with:
```
	Encountered an error:
	Compilation Error in model test_hash (models/cross_db_utils/test_hash.sql)
  	In dispatch: Could not find package 'materialize_dbt_utils'
```