### PR TITLE
fix a few broken integration tests

### DIFF
--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -20,3 +20,22 @@ vars:
   dbt_utils_dispatch_list:
     - materialize_dbt_utils
     - dbt_utils_integration_tests
+
+models:
+  # More info about disabled tests: https://github.com/MaterializeInc/materialize-dbt-utils/issues/7
+  dbt_utils_integration_tests:
+    cross_db_utils:
+      # Materialize doesn't support current_timestamp() in static queries
+      test_current_timestamp:
+        +enabled: false
+      test_current_timestamp_in_utc:
+        +enabled: false
+      # Materialize does not currently support md5
+      # See: https://github.com/MaterializeInc/materialize/issues/4461
+      test_hash:
+        +enabled: false
+    sql:
+      # Materialize does not currently support md5
+      # See: https://github.com/MaterializeInc/materialize/issues/4461
+      test_surrogate_key:
+        +enabled: false

--- a/macros/dbt_utils/date_trunc.sql
+++ b/macros/dbt_utils/date_trunc.sql
@@ -1,0 +1,6 @@
+{% macro materialize__date_trunc(datepart, date) %}
+    date_trunc(
+        {{datepart}},
+         cast({{date}} as timestamp)
+    )
+{% endmacro %}

--- a/macros/dbt_utils/dateadd.sql
+++ b/macros/dbt_utils/dateadd.sql
@@ -1,0 +1,3 @@
+{% macro materialize__dateadd(datepart, interval, from_date_or_timestamp) %}
+    cast( {{ from_date_or_timestamp }} as timestamp) + ((interval '1 {{ datepart }}') * ({{ interval }}))
+{% endmacro %}


### PR DESCRIPTION
Fixes part of #7.

Won't fix the tests explicitly listed in `dbt_project.yml`, each skipped test is accompanied by an explanation. Fixes `date_trunc` and `dateadd`.

