### PR TITLE
Do not rely on a default target in the dbt profile yaml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+We welcome contributions to this repo! To contribute a new feature or a fix,
+please open a Pull Request with 1) your changes and 2) updated documentation for
+the `README.md` file.
+
+## Testing
+
+To run the integration tests, do the following:
+
+1. [Run `materialized` locally](https://materialize.com/docs/get-started/#install-run-connect).
+
+2. Add the following profile to your profiles.yml file to configure the
+   integration tests to run against the `materialized` process you just started:
+
+   ```yml
+   integration_tests:
+     outputs:
+       materialize:
+         type: materialize
+         threads: 1
+         host: localhost
+         port: 6875
+         user: user
+         password: password
+         dbname: materialize
+         schema: public
+   ```
+
+   You can run `dbt debug` to locate your profiles.yml file if necessary.
+
+3. Run the tests:
+
+   ```
+   cd integration_tests/dbt_utils
+   make test-materialize [TARGET=custom-profile-target-name]
+   ```

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,0 +1,20 @@
+# Maintainer instructions
+
+## Cutting a new release
+
+1. Check out the latest `main` branch locally.
+
+2. Create an annotated tag for the new version:
+
+   ```
+   git tag -a vX.Y.Z -m vX.Y.Z
+   ```
+
+3. Push that tag to GitHub:
+
+   ```
+   git push vX.Y.Z
+   ```
+
+4. Verify that CI passes on the tag and publishes a GitHub release.
+

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Check [dbt Hub](https://hub.getdbt.com) for the latest installation
 instructions, or [read the docs](https://docs.getdbt.com/docs/package-management)
 for more information on installing packages.
 
-----
-
 ## Macros
 
 The following sections document the macro support for Materialize. For more information
@@ -78,7 +76,7 @@ about the macros themselves, please visit [`dbt_utils`](https://github.com/fisht
 | `get_url_host` | :question: | Untested |
 | `get_url_path` | :x: | TODO |
 
-### Logger 
+### Logger
 | Name | Supported? | Notes |
 |------|------------|-------|
 | `pretty_time` | :question: | Untested |
@@ -89,46 +87,6 @@ about the macros themselves, please visit [`dbt_utils`](https://github.com/fisht
 | Name | Supported? | Notes |
 |------|------------|-------|
 | `insert_by_period` | :question: | Untested |
-
-----
-
-### Testing
-
-To run the integration tests, do the following:
-1. Git clone this repository
-1. Add the following profile to your list of dbt profiles (run `dbt debug` to locate
-   your local profiles):
-   ```nofmt
-   integration_tests:
-     outputs:
-       materialize:
-         type: materialize
-         threads: 1
-         host: localhost
-         port: 6875
-         user: user
-         password: password
-         dbname: materialize
-         schema: public
-   ```
-1. In your terminal, navigate to the `integration_tests/dbt_utils` subdirectory:
-    ```nofmt
-   cd integration_tests/dbt_utils
-   ```
-1. Run the tests:
-    ```nofmt
-   make test-materialize [target=custom-target-name:materialize]
-   ```
-
-----
-
-### Contributing
-
-We welcome contributions to this repo! To contribute a new feature or a fix,
-please open a Pull Request with 1) your changes and 2) updated documentation for
-the `README.md` file.
-
-----
 
 ### Getting started with dbt + Materialize
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To run the integration tests, do the following:
    ```nofmt
    integration_tests:
      outputs:
-       dev:
+       materialize:
          type: materialize
          threads: 1
          host: localhost
@@ -110,7 +110,6 @@ To run the integration tests, do the following:
          password: password
          dbname: materialize
          schema: public
-     target: dev
    ```
 1. In your terminal, navigate to the `integration_tests/dbt_utils` subdirectory:
     ```nofmt
@@ -118,7 +117,7 @@ To run the integration tests, do the following:
    ```
 1. Run the tests:
     ```nofmt
-   make test-materialize
+   make test-materialize [target=custom-target-name:materialize]
    ```
 
 ----

--- a/integration_tests/dbt_utils/Makefile
+++ b/integration_tests/dbt_utils/Makefile
@@ -1,6 +1,7 @@
+TARGET ?= materialize
 
 test-materialize:
 	dbt deps
-	dbt seed
-	dbt run
-	dbt test
+	dbt seed --target $(TARGET)
+	dbt run --target $(TARGET)
+	dbt test --target $(TARGET)


### PR DESCRIPTION
Hi!

First of all, great stuff! I think dbt+Materialize could be a great combination!

I'm trying to get the dbt-materialize-utils to work and I followed the readme so far. A year ago I worked on the `dbt-utils` project itself and i already had an `integration_tests` profile with connections to other targets. From that perspective it doesn't make sense to make one target the default.

My proposed solution would be to solve this in the used Makefile by explicitly stating the target to be used. This can default to `materialize` (I would prefer that as the target over `dev`) so from a user perspective behaves similar as before. In case your target is named differently, you could specify it by running `make test-materialize target=dev` e.g.

What do you think?