### PR TITLE
README: mark time-related functions as usable now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
       - name: Setup
         run: |
-          pip install dbt-materialize==1.0.1.post2
+          pip install dbt-materialize==1.0.3
           mkdir -p ~/.dbt
           cat > ~/.dbt/profiles.yml <<EOF
           config:
@@ -42,5 +42,5 @@ jobs:
 
     services:
       materialized:
-        image: materialize/materialized:v0.20.0
+        image: materialize/materialized:v0.22.0
         ports: ["6875:6875"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 * Bump the minimum supported version of Materialize to v0.22.0+.
 
-* Mark the `recency` and `current_timestamp` macros as supported.
+* Support and test the `recency` and `current_timestamp` macros.
+
+* Correctly mark the `insert_by_period` macro as unsupported.
 
 ## 0.2.0 - 2021-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # materialize-dbt-utils Changelog
 
+## 0.3.0 - 2021-03-03
+
+* Bump the minimum supported version of dbt-materialize to v1.0.3.
+
+* Bump the minimum supported version of Materialize to v0.22.0+.
+
+* Mark the `recency` and `current_timestamp` macros as supported.
+
 ## 0.2.0 - 2021-02-14
 
 * Fix the `last_day` macro.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Name                               | Supported?         | Notes
 [`relationships_where`]            | :white_check_mark: |
 [`sequential_values`]              | :x:                | Materialize does not support the `lag` window function.
 [`mutually_exclusive_ranges`]      | :x:                | Materialize does not support the `lead` window function.
-[`unique_combinations_of_columns`] | :white_check_mark: |
+[`unique_combination_of_columns`]  | :white_check_mark: |
 [`accepted_range`]                 | :white_check_mark: |
 
 ### [`dbt-utils` macros]
@@ -129,7 +129,7 @@ Name                  | Supported?         | Notes
 
 Name                 | Supported?         | Notes
 ---------------------|--------------------|------
-[`insert_by_period`] | :white_check_mark: |
+[`insert_by_period`] | :x:                | Materialize natively provides incremental view maintenance.
 
 [`accepted_range`]: https://github.com/dbt-labs/dbt-utils#accepted_range-source
 [`at_least_one`]: https://github.com/dbt-labs/dbt-utils#at_least_one-source
@@ -177,6 +177,7 @@ Name                 | Supported?         | Notes
 [`surrogate_key`]: https://github.com/dbt-labs/dbt-utils#surrogate_key-source
 [`union_relations`]: https://github.com/dbt-labs/dbt-utils#union_relations-source
 [`unique_where`]: https://github.com/dbt-labs/dbt-utils#unique_where-source
+[`unique_combination_of_columns`]: https://github.com/dbt-labs/dbt-utils#unique_combination_of_columns-source
 [`unpivot`]: https://github.com/dbt-labs/dbt-utils#unpivot-source
 [`width_bucket`]: https://github.com/dbt-labs/dbt-utils#width_bucket-source
 [Cross-database macros]: https://github.com/dbt-labs/dbt-utils#cross-database-macros

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ following packages with [Materialize]:
 ## Installation
 
 Requirements:
-- [dbt-materialize](https://pypi.org/project/dbt-materialize/) v1.0.1.post2+
-- [Materialize](https://materialize.com/docs/install/) v0.20.0+
+- [dbt-materialize](https://pypi.org/project/dbt-materialize/) v1.0.3
+- [Materialize](https://materialize.com/docs/install/) v0.22.0+
 
 Install this package by adding the following to the `packages.yml` file in your
 root dbt project:
@@ -26,7 +26,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.0
   - package: MaterializeInc/materialize_dbt_utils
-    version: 0.2.0
+    version: 0.3.0
 ```
 
 Then set a `dispatch` config in your `dbt_project.yml:
@@ -56,7 +56,7 @@ Name                               | Supported?         | Notes
 [`fewer_rows_than`]                | :white_check_mark: |
 [`equality`]                       | :white_check_mark: |
 [`expression_is_true`]             | :white_check_mark: |
-[`recency`]                        | :x:                | Materialize does not support creating views containing `current_timestamp`.
+[`recency`]                        | :white_check_mark: |
 [`at_least_one`]                   | :white_check_mark: |
 [`not_constant`]                   | :white_check_mark: |
 [`cardinality_equality`]           | :white_check_mark: |
@@ -108,7 +108,7 @@ Name                  | Supported?         | Notes
 
 Name                  | Supported?         | Notes
 ----------------------|--------------------|------
-[`current_timestamp`] | :x:                | Materialize does not support creating views containing `current_timestamp`.
+[`current_timestamp`] | :white_check_mark: |
 [`dateadd`]           | :white_check_mark: |
 [`datediff`]          | :white_check_mark: |
 [`split_part`]        | :white_check_mark: |

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'materialize_dbt_utils'
-version: '0.1.0'
+version: '0.3.0'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -27,17 +27,11 @@ seeds:
 
 models:
   dbt_utils_integration_tests:
-    # Materialize doesn't support creating views containing current_timestamp.
-    cross_db_utils:
-      test_current_timestamp:
-        +enabled: false
-      test_current_timestamp_in_utc:
-        +enabled: false
-    schema_tests:
-      test_recency:
-        +enabled: false
-
     datetime:
       # Tested by test_date_spine_override.
       test_date_spine:
+        +enabled: false
+    schema_tests:
+      # Tested by test_recency_override.
+      test_recency:
         +enabled: false

--- a/integration_tests/dbt_utils/models/schema_tests/schema.yml
+++ b/integration_tests/dbt_utils/models/schema_tests/schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: test_recency_override
+    tests:
+      - dbt_utils.recency:
+          datepart: day
+          field: today
+          interval: 1

--- a/integration_tests/dbt_utils/models/schema_tests/test_recency_override.sql
+++ b/integration_tests/dbt_utils/models/schema_tests/test_recency_override.sql
@@ -1,0 +1,6 @@
+-- The upstream test_recency has PostgreSQL-specific logic that doesn't
+-- get picked up because it conditions on `target == "postgres"`. So we just
+-- hardcode that PostgreSQL-specific logic here.
+
+select
+    {{ dbt_utils.date_trunc('day', dbt_utils.current_timestamp()) }} as today


### PR DESCRIPTION
These functions are now usable in views as long as they are not
materialized.