### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0 - 2022-05-05
 
-* Shim `dbt-audit-helper` ([v0.5.0](https://github.com/dbt-labs/dbt-audit-helper/releases/tag/0.5.0)).
+* Shim `dbt-audit-helper` ([v0.5.0](https://github.com/dbt-labs/dbt-audit-helper/releases/tag/0.5.0)) macros for compatibility.
 
 ## 0.3.0 - 2022-03-03
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'materialize_dbt_utils'
-version: '0.3.0'
+version: '0.4.0'
 config-version: 2
 
 require-dbt-version: ">=1.0.0"


### PR DESCRIPTION
Missed bumping the version in `project.yml` in #20, so creating a dedicated release PR to then push the `v0.4.0` tag.