### PR TITLE
Enable support for lead- and lag-using macros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,5 +45,5 @@ jobs:
 
     services:
       materialized:
-        image: materialize/materialized:v0.22.0
+        image: materialize/materialized:v0.26.3
         ports: ["6875:6875"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # materialize-dbt-utils Changelog
 
+## 0.5.0 - 2022-06-24
+
+* Bump the minimum supported version of Materialize to v0.26.3.
+
+* Support and test the `sequential_values` and `mutually_exclusive_ranges` macros.
+
 ## 0.4.0 - 2022-05-05
 
 * Shim `dbt-audit-helper` ([v0.5.0](https://github.com/dbt-labs/dbt-audit-helper/releases/tag/0.5.0)) macros for compatibility.

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -112,3 +112,4 @@ To run the suite of integration tests:
 [.github/workflows/main.yml]: .github/workflows/main.yml
 [dbt_project.yml]: dbt_project.yml
 [CHANGELOG.md]: CHANGELOG.md
+[README.md]: README.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ following packages with [Materialize]:
 
 Requirements:
 - [dbt-materialize](https://pypi.org/project/dbt-materialize/) v1.0.3+
-- [Materialize](https://materialize.com/docs/install/) v0.22.0+
+- [Materialize](https://materialize.com/docs/install/) v0.26.3+
 
 Install this package by adding the following to the `packages.yml` file in your
 root dbt project:
@@ -27,7 +27,7 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 0.8.0
   - package: MaterializeInc/materialize_dbt_utils
-    version: 0.4.0
+    version: 0.5.0
 ```
 
 Then set a `dispatch` config in your `dbt_project.yml`:
@@ -68,8 +68,8 @@ Name                               | Supported?         | Notes
 [`not_null_proportion`]            | :white_check_mark: |
 [`not_accepted_values`]            | :white_check_mark: |
 [`relationships_where`]            | :white_check_mark: |
-[`sequential_values`]              | :x:                | Materialize does not support the `lag` window function.
-[`mutually_exclusive_ranges`]      | :x:                | Materialize does not support the `lead` window function.
+[`sequential_values`]              | :white_check_mark: |
+[`mutually_exclusive_ranges`]      | :white_check_mark: |
 [`unique_combination_of_columns`]  | :white_check_mark: |
 [`accepted_range`]                 | :white_check_mark: |
 

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -8,23 +8,6 @@ dispatch:
   - macro_namespace: dbt_utils
     search_order: [materialize_dbt_utils, dbt_utils_integration_tests, dbt_utils]
 
-seeds:
-  dbt_utils_integration_tests:
-    schema_tests:
-      # Materialize does not support the `lead` window function.
-      data_test_mutually_exclusive_ranges_no_gaps:
-        +enabled: false
-      data_test_mutually_exclusive_ranges_with_gaps:
-        +enabled: false
-      data_test_mutually_exclusive_ranges_with_gaps_zero_length:
-        +enabled: false
-
-      # Materialize does not support the `lag` window function.
-      data_test_sequential_timestamps:
-        +enabled: false
-      data_test_sequential_values:
-        +enabled: false
-
 models:
   dbt_utils_integration_tests:
     datetime:


### PR DESCRIPTION
Materialize v0.26.3 got support for the lead and lag window functions,
so we can enable the last few macros that depended upon those window
functions.

Fix #17.