### PR TITLE
dbt v1.2: move cross db dbt-utils macros into dbt-materialize

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,4 +2,4 @@ name: 'materialize_dbt_utils'
 version: '0.4.0'
 config-version: 2
 
-require-dbt-version: ">=1.0.0"
+require-dbt-version: ">=1.2.0"

--- a/macros/dbt_utils/.gitignore
+++ b/macros/dbt_utils/.gitignore
@@ -1,4 +1,0 @@
-
-target/
-dbt_modules/
-logs/

--- a/macros/dbt_utils/dateadd.sql
+++ b/macros/dbt_utils/dateadd.sql
@@ -1,3 +1,0 @@
-{% macro materialize__dateadd(datepart, interval, from_date_or_timestamp) %}
-    {{ return(dbt_utils.postgres__dateadd(datepart, interval, from_date_or_timestamp)) }}
-{% endmacro %}

--- a/macros/dbt_utils/datediff.sql
+++ b/macros/dbt_utils/datediff.sql
@@ -1,3 +1,0 @@
-{% macro materialize__datediff(first_date, second_date, datepart) %}
-    {{ return(dbt_utils.postgres__datediff(first_date, second_date, datepart)) }}
-{% endmacro %}

--- a/macros/dbt_utils/last_day.sql
+++ b/macros/dbt_utils/last_day.sql
@@ -1,3 +1,0 @@
-{% macro materialize__last_day(date, date_part) %}
-    {{ return(dbt_utils.postgres__last_day(date, date_part)) }}
-{% endmacro %}


### PR DESCRIPTION
Closes the cross db compatibility portion of the adapter guide for[ upgrading to v1.2](https://github.com/dbt-labs/dbt-core/discussions/5468) and our corresponding tracking issue https://github.com/MaterializeInc/database-issues/issues/3954.

Materialize issue: https://github.com/MaterializeInc/materialize/pull/15775