### PR TITLE
Soft deprecate cross-DB macros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: true
       - name: Setup
         run: |
-          pip install dbt-materialize==1.0.3
+          pip install dbt-materialize==1.3.0
           mkdir -p ~/.dbt
           cat > ~/.dbt/profiles.yml <<EOF
           config:
@@ -45,5 +45,5 @@ jobs:
 
     services:
       materialized:
-        image: materialize/materialized:v0.26.3
+        image: materialize/materialized:v0.26.5
         ports: ["6875:6875"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # materialize-dbt-utils Changelog
 
+## Unreleased
+
+* Deprecate the `dateadd`, `datediff`, `last_day` macros. These macros have been
+  moved into dbt Core in [dbt-core #5298](https://github.com/dbt-labs/dbt-core/pull/5298),
+  and will be removed in a subsequent release.
+
 ## 0.5.0 - 2022-06-24
 
 * Bump the minimum supported version of Materialize to v0.26.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bump the minimum supported version of `dbt-materialize` to v1.3.0.
+
 * Deprecate the `dateadd`, `datediff`, `last_day` macros. These macros have been
   moved into dbt Core in [dbt-core #5298](https://github.com/dbt-labs/dbt-core/pull/5298),
   and will be removed in a subsequent release.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ following packages with [Materialize]:
 ## Installation
 
 Requirements:
-- [dbt-materialize](https://pypi.org/project/dbt-materialize/) v1.0.3+
-- [Materialize](https://materialize.com/docs/install/) v0.26.3+
+- [dbt-materialize](https://pypi.org/project/dbt-materialize/) v1.3.0+
+- [Materialize](https://materialize.com/docs/install/) v0.26.5+
 
 Install this package by adding the following to the `packages.yml` file in your
 root dbt project:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ root dbt project:
 ```
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.8.0
+    version: 0.9.2
   - package: MaterializeInc/materialize_dbt_utils
     version: 0.5.0
 ```

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'materialize_dbt_utils'
-version: '0.4.0'
+version: '0.5.0'
 config-version: 2
 
-require-dbt-version: ">=1.0.0"
+require-dbt-version: [">=1.0.3", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -2,4 +2,4 @@ name: 'materialize_dbt_utils'
 version: '0.5.0'
 config-version: 2
 
-require-dbt-version: [">=1.0.3", "<2.0.0"]
+require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,3 +1,3 @@
 name: 'materialize_dbt_utils_integration_tests'
-version: '0.1.0'
+version: '0.5.0'
 config-version: 2

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -30,8 +30,15 @@ models:
       # Tested by test_recency_override.
       test_recency:
         +enabled: false
+
 seeds:
   dbt_utils_integration_tests:
     sql:
       data_get_column_values_dropped:
+        +enabled: false
+    schema_tests:
+      # TODO(morsapaes): Enable once materialize #15863 lands
+      data_test_mutually_exclusive_ranges_with_gaps:
+        +enabled: false
+      data_test_mutually_exclusive_ranges_with_gaps_zero_length:
         +enabled: false

--- a/integration_tests/dbt_utils/dbt_project.yml
+++ b/integration_tests/dbt_utils/dbt_project.yml
@@ -4,6 +4,18 @@ config-version: 2
 
 profile: integration_tests
 
+model-paths: ["models"]
+analysis-paths: ["analysis"]
+test-paths: ["tests"]
+seed-paths: ["data"]
+macro-paths: ["macros"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+    - "target"
+    - "dbt_modules"
+    - "dbt_packages"
+
 dispatch:
   - macro_namespace: dbt_utils
     search_order: [materialize_dbt_utils, dbt_utils_integration_tests, dbt_utils]
@@ -17,4 +29,9 @@ models:
     schema_tests:
       # Tested by test_recency_override.
       test_recency:
+        +enabled: false
+seeds:
+  dbt_utils_integration_tests:
+    sql:
+      data_get_column_values_dropped:
         +enabled: false

--- a/macros/dbt_utils/dateadd.sql
+++ b/macros/dbt_utils/dateadd.sql
@@ -1,3 +1,11 @@
 {% macro materialize__dateadd(datepart, interval, from_date_or_timestamp) %}
-    {{ return(dbt_utils.postgres__dateadd(datepart, interval, from_date_or_timestamp)) }}
+    {{ exceptions.warn(
+        """
+        The dateadd macro has been moved to dbt Core; use the macro directly.
+        dbt_utils.dateadd is deprecated and will be removed in a future release
+        of materialize-dbt-utils.
+        """
+    )}}
+
+    {{ return(adapter.dispatch('dateadd','dbt')(datepart, interval, from_date_or_timestamp)) }}
 {% endmacro %}

--- a/macros/dbt_utils/datediff.sql
+++ b/macros/dbt_utils/datediff.sql
@@ -1,3 +1,12 @@
 {% macro materialize__datediff(first_date, second_date, datepart) %}
-    {{ return(dbt_utils.postgres__datediff(first_date, second_date, datepart)) }}
+
+    {{ exceptions.warn(
+        """
+        The datediff macro has been moved to dbt Core; use the macro directly.
+        dbt_utils.datediff is deprecated and will be removed in a future release
+        of materialize-dbt-utils.
+        """
+    )}}
+
+    {{ return(adapter.dispatch('datediff','dbt')(first_date, second_date, datepart)) }}
 {% endmacro %}

--- a/macros/dbt_utils/last_day.sql
+++ b/macros/dbt_utils/last_day.sql
@@ -1,3 +1,12 @@
 {% macro materialize__last_day(date, date_part) %}
-    {{ return(dbt_utils.postgres__last_day(date, date_part)) }}
+
+    {{ exceptions.warn(
+        """
+        The last_day macro has been moved to dbt Core; use the macro directly.
+        dbt_utils.last_day is deprecated and will be removed in a future release
+        of materialize-dbt-utils.
+        """
+    )}}
+
+    {{ return(adapter.dispatch('last_day','dbt')(date, date_part)) }}
 {% endmacro %}


### PR DESCRIPTION
`materialize-dbt-utils` counterpart to [materialize MaterializeInc/materialize#15775](https://github.com/MaterializeInc/materialize/pull/15775). The migrated macros are soft deprecated for backwards compatibility, and will be removed in a subsequent release of the package.

## Tips for reviewer
The `data_get_column_values_dropped` integration test is failing with an error I couldn't wrap my head around yet, and `data_test_mutually_exclusive_ranges_with_gaps(_zero_length)` is failing due to [materialize MaterializeInc/database-issues#4564](https://github.com/MaterializeInc/database-issues/issues/4564). The first doesn't seem to be tied to any of the recent changes, as it reproduces for older versions of the adapter. Disabled both for now, and will look into a fix in the context of MaterializeInc/database-issues#19.

