### PR TITLE
Mark `date_spine` as migrated to `dbt-core`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Name                          | Supported?         | Notes
 
 Name                   | Supported?         | Notes
 -----------------------|--------------------|-------
-[`date_spine`]         | :white_check_mark: |
+[`date_spine`]         | :white_check_mark: | Migrated to dbt Core
 [`haversine_distance`] | :white_check_mark: |
 [`group_by`]           | :white_check_mark: |
 [`star`]               | :white_check_mark: |


### PR DESCRIPTION
With dbt v1.7, `date_spine` has been migrated off `dbt-utils` to `dbt-core` (see [dbt Core #8616](https://github.com/dbt-labs/dbt-core/pull/8616)).

Probably needs a few more tweaks elsewhere in the repo, but opening a basic PR so we remember to update this as part of [Materialize #23004](https://github.com/MaterializeInc/materialize/pull/23004).